### PR TITLE
auth refactor

### DIFF
--- a/src/components/AuthModal/Form/ForgotPassword.tsx
+++ b/src/components/AuthModal/Form/ForgotPassword.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import React, { useEffect } from "react";
-import { useForm } from "react-hook-form";
+import React, { useState } from "react";
+import { SubmitHandler, useForm } from "react-hook-form";
 import {
   ForgotPasswordFormData,
   forgotPasswordSchema,
@@ -9,8 +9,8 @@ import { useAuthStore } from "../../../stores/authStore";
 import { toast } from "sonner";
 
 export const ForgotPassword: React.FC = () => {
-  const { forgotPassword, forgotPasswordSuccess, reset, isLoading, error } =
-    useAuthStore();
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const { forgotPassword, isLoading } = useAuthStore();
   const {
     register,
     handleSubmit,
@@ -19,23 +19,15 @@ export const ForgotPassword: React.FC = () => {
     resolver: zodResolver(forgotPasswordSchema),
   });
 
-  useEffect(() => {
-    if (forgotPasswordSuccess) {
+  const onSubmit: SubmitHandler<ForgotPasswordFormData> = async (data) => {
+    try {
+      await forgotPassword(data);
       toast.success("Email enviado com sucesso.");
+      setIsSubmitted(true);
+    } catch (err: any) {
+      console.log(err);
+      toast.error(err.message || "Ocorreu um erro desconhecido");
     }
-    if (error) {
-      toast.error(error);
-    }
-
-    return () => {
-      if (forgotPasswordSuccess || error) {
-        reset();
-      }
-    };
-  }, [forgotPasswordSuccess, error, reset]);
-
-  const onSubmit = (data: ForgotPasswordFormData) => {
-    forgotPassword(data);
   };
 
   return (
@@ -54,7 +46,7 @@ export const ForgotPassword: React.FC = () => {
           )}
         </section>
         <p className="info-text">
-          {forgotPasswordSuccess
+          {isSubmitted
             ? "Se o endereço de email está correto, um link para recuperação foi enviado!"
             : `Enviaremos um e-mail para a recuperação de sua senha.`}
         </p>

--- a/src/components/AuthModal/Form/RecoveryPassword.tsx
+++ b/src/components/AuthModal/Form/RecoveryPassword.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import React, { useEffect } from "react";
+import React from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
 import {
   RecoveryPasswordFormData,
@@ -10,8 +10,7 @@ import { useAuthModalStore } from "../../../stores/authModalStore";
 import { toast } from "sonner";
 
 export const RecoveryPassword: React.FC = () => {
-  const { resetPassword, isLoading, error, passwordResetSuccess, reset } =
-    useAuthStore();
+  const { resetPassword, isLoading, error: authError } = useAuthStore();
   const { recoveryToken, openModal } = useAuthModalStore();
   const {
     register,
@@ -21,25 +20,10 @@ export const RecoveryPassword: React.FC = () => {
     resolver: zodResolver(recoveryPasswordSchema),
   });
 
-  useEffect(() => {
-    if (passwordResetSuccess) {
-      toast.success("Sua senha foi alterada com sucesso!");
-      openModal("signIn");
-    }
-    if (error) {
-      toast.error(error);
-    }
-
-    return () => {
-      if (passwordResetSuccess || error) {
-        reset();
-      }
-    };
-  }, [passwordResetSuccess, error, reset, openModal]);
-
-  const onSubmit: SubmitHandler<RecoveryPasswordFormData> = (data) => {
+  const onSubmit: SubmitHandler<RecoveryPasswordFormData> = async (data) => {
     if (!recoveryToken) {
       console.error("Token de recuperação não encontrado!");
+      toast.error("Token de recuperação não encontrado!");
       return;
     }
 
@@ -48,7 +32,14 @@ export const RecoveryPassword: React.FC = () => {
       token: recoveryToken,
     };
 
-    resetPassword(apiPayload);
+    try {
+      await resetPassword(apiPayload);
+      toast.success("Sua senha foi alterada com sucesso!");
+      openModal("signIn");
+    } catch (err: any) {
+      console.log(err);
+      toast.error(err.message || "Ocorreu um erro desconhecido");
+    }
   };
   return (
     <form className="auth-form" onSubmit={handleSubmit(onSubmit)}>
@@ -92,6 +83,7 @@ export const RecoveryPassword: React.FC = () => {
       </div>
       <button type="submit" className="btn-submit">
         {isLoading ? "Enviando. . ." : "Enviar"}
+        {authError && <p>{authError}</p>}
       </button>
     </form>
   );

--- a/src/components/AuthModal/Form/SignIn.tsx
+++ b/src/components/AuthModal/Form/SignIn.tsx
@@ -1,16 +1,15 @@
-import React, { useEffect } from "react";
-import { useForm } from "react-hook-form";
+import React from "react";
+import { SubmitHandler, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { SignInFormData, signInSchema } from "../../../schema/authSchema";
 import { useAuthStore } from "../../../stores/authStore";
 import { toast } from "sonner";
 import { SignInProps } from "../../../types/authTypes";
+import { useAuthModalStore } from "../../../stores/authModalStore";
 
-export const SignIn: React.FC<SignInProps> = ({
-  onForgot,
-  onSignInSuccess,
-}) => {
-  const { signIn, isLoading, error, success, reset } = useAuthStore();
+export const SignIn: React.FC<SignInProps> = ({ onForgot }) => {
+  const { signIn, isLoading, error: authError } = useAuthStore();
+  const { closeModal } = useAuthModalStore();
   const {
     register,
     handleSubmit,
@@ -19,21 +18,15 @@ export const SignIn: React.FC<SignInProps> = ({
     resolver: zodResolver(signInSchema),
   });
 
-  useEffect(() => {
-    if (success) {
+  const onSubmit: SubmitHandler<SignInFormData> = async (data) => {
+    try {
+      await signIn(data);
       toast.success("Login realizado com sucesso!");
-      onSignInSuccess();
-
-      reset();
+      closeModal();
+    } catch (err: any) {
+      console.log(err);
+      toast.error(err.message || "Ocorreu um erro desconhecido");
     }
-    if (error) {
-      toast.error(`${error}: Credenciais invalidas.`);
-      reset();
-    }
-  }, [success, error, reset, onSignInSuccess]);
-
-  const onSubmit = (data: SignInFormData) => {
-    signIn(data);
   };
 
   return (
@@ -72,6 +65,7 @@ export const SignIn: React.FC<SignInProps> = ({
       <button type="submit" className="btn-submit" disabled={isLoading}>
         {isLoading ? "Entrando. . ." : "Entrar"}
       </button>
+      {authError && <p>{authError}</p>}
     </form>
   );
 };

--- a/src/components/AuthModal/Form/SignUp.tsx
+++ b/src/components/AuthModal/Form/SignUp.tsx
@@ -1,13 +1,13 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import React, { useEffect } from "react";
-import { useForm } from "react-hook-form";
+import React from "react";
+import { SubmitHandler, useForm } from "react-hook-form";
 import { SignUpFormData, signUpSchema } from "../../../schema/authSchema";
 import { useAuthStore } from "../../../stores/authStore";
 import { toast } from "sonner";
 import { SingUpProps } from "../../../types/authTypes";
 
 export const SignUp: React.FC<SingUpProps> = ({ onSignUpSuccess }) => {
-  const { signUp, isLoading, error, signUpSuccess, reset } = useAuthStore();
+  const { signUp, isLoading, error: authError } = useAuthStore();
 
   const {
     register,
@@ -17,21 +17,15 @@ export const SignUp: React.FC<SingUpProps> = ({ onSignUpSuccess }) => {
     resolver: zodResolver(signUpSchema),
   });
 
-  useEffect(() => {
-    if (signUpSuccess) {
+  const onSubmit: SubmitHandler<SignUpFormData> = async (data) => {
+    try {
+      await signUp(data);
       toast.success("Cadastro realizado com sucesso!");
       onSignUpSuccess();
-
-      reset();
+    } catch (err: any) {
+      console.log(err);
+      toast.error(err.message || "Ocorreu um erro desconhecido");
     }
-    if (error) {
-      toast.error(error);
-      reset();
-    }
-  }, [signUpSuccess, error, reset, onSignUpSuccess]);
-
-  const onSubmit = (data: SignUpFormData) => {
-    signUp(data);
   };
 
   return (
@@ -79,6 +73,7 @@ export const SignUp: React.FC<SingUpProps> = ({ onSignUpSuccess }) => {
       </div>
       <button type="submit" className="btn-submit" disabled={isLoading}>
         {isLoading ? "Cadastrando..." : "Cadastrar"}
+        {authError && <p>{authError}</p>}
       </button>
     </form>
   );

--- a/src/components/AuthModal/index.tsx
+++ b/src/components/AuthModal/index.tsx
@@ -5,11 +5,9 @@ import { logoCodePrimary } from "../../assets/images/svg/icons";
 import { ProfessorCorrea } from "../../assets/images/svg/illustration";
 import { useNavigate } from "react-router-dom";
 import { useAuthModalStore } from "../../stores/authModalStore";
-import { useAuthStore } from "../../stores/authStore";
 
 export const AuthModal: React.FC = () => {
   const { type: currentType, closeModal, openModal } = useAuthModalStore();
-  const { reset } = useAuthStore();
   const [windowWidth, setWindowWidth] = useState(window.innerWidth);
   const navigate = useNavigate();
 
@@ -27,7 +25,6 @@ export const AuthModal: React.FC = () => {
 
   const handleClose = () => {
     closeModal();
-    reset();
   };
 
   const renderNames = () => {

--- a/src/pages/ProfilePage/index.tsx
+++ b/src/pages/ProfilePage/index.tsx
@@ -10,13 +10,12 @@ export const ProfilePage: React.FC = () => {
 
   useEffect(() => {
     fetchCurrentUser();
-  }, [fetchCurrentUser]);
+  }, []);
 
   if (!currentUser) {
     return <div>Carregando perfil...</div>;
   }
 
-  console.log(currentUser.avatarUrl);
   return (
     <>
       <div className="profile-page-wrapper">

--- a/src/routes/guards/authGuard.tsx
+++ b/src/routes/guards/authGuard.tsx
@@ -1,24 +1,23 @@
-import React from "react";
-import { Navigate } from "react-router-dom";
-import { useUserStore } from "../../stores/userStore";
+import React, { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { useAuthModalStore } from "../../stores/authModalStore";
+import { useAuthStore } from "../../stores/authStore";
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
 }
 
 export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
-  const { currentUser, isLoading: userLoading } = useUserStore();
+  const { token } = useAuthStore();
   const { openModal } = useAuthModalStore();
+  const navigate = useNavigate();
 
-  if (userLoading) {
-    return <div>Loading...</div>;
-  }
+  useEffect(() => {
+    if (!token) {
+      openModal("signIn");
+      navigate("/", { replace: true });
+    }
+  }, [token, openModal, navigate]);
 
-  if (!currentUser) {
-    openModal("signIn");
-    return <Navigate to="/" replace />;
-  }
-
-  return <>{children}</>;
+  return token ? <>{children}</> : null;
 };

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const apiBaseUrl = import.meta.env.DEV
-  ? "http://localhost:3000"
+  ? "http://localhost:8080"
   : import.meta.env.VITE_API_BASE_URL;
 
 export const api = axios.create({

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -7,10 +7,6 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   isLoading: false,
   error: null,
   token: null,
-  success: false,
-  forgotPasswordSuccess: false,
-  passwordResetSuccess: false,
-  signUpSuccess: false,
 
   setToken: (t) => {
     if (t) localStorage.setItem("authToken", t);
@@ -25,7 +21,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
   logout: () => {
     localStorage.removeItem("authToken");
-    set({ token: null, isLoading: false, error: null, success: false });
+    set({ token: null, isLoading: false, error: null });
     useUserStore.getState().clearUser();
   },
 
@@ -35,59 +31,55 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       const response = await api.post("/auth/login", data);
       const { access_token } = response.data;
       get().setToken(access_token);
-      set({ isLoading: false, success: true });
     } catch (err: any) {
       const message =
         err.response?.data?.message || "Email ou senha inválidos.";
-      set({ isLoading: false, error: message });
+      set({ error: message });
+      throw new Error(message);
+    } finally {
+      set({ isLoading: false });
     }
   },
 
   signUp: async (data) => {
-    set({ isLoading: true, error: null, signUpSuccess: false });
+    set({ isLoading: true, error: null });
     try {
       await api.post("/auth/register", data);
-      set({ isLoading: false, signUpSuccess: true });
     } catch (err: any) {
       const message =
         err.response?.data?.message || "Falha ao cadastrar. Tente novamente";
-      set({ isLoading: false, error: message });
+      set({ error: message });
+      throw new Error(message);
+    } finally {
+      set({ isLoading: false });
     }
   },
 
   forgotPassword: async (data) => {
-    set({ isLoading: true, error: null, forgotPasswordSuccess: false });
+    set({ isLoading: true, error: null });
     try {
       await api.post("/auth/forgot-password", data);
-      set({ isLoading: false, forgotPasswordSuccess: true });
     } catch (err: any) {
       const message =
         err.response?.data?.message || "Verifique se o email está correto";
-      set({ isLoading: false, error: message });
+      set({ error: message });
+      throw new Error(message);
+    } finally {
+      set({ isLoading: false });
     }
   },
 
   resetPassword: async (data) => {
-    set({ isLoading: true, error: null, passwordResetSuccess: false });
+    set({ isLoading: true, error: null });
     try {
       await api.post("/auth/reset-password", data);
-      set({ isLoading: false, passwordResetSuccess: true });
     } catch (err: any) {
       const message =
-        err.response?.data?.message || "Token inválçido ou expirado.";
-      set({ isLoading: false, error: message });
+        err.response?.data?.message || "Token inválido ou expirado.";
+      set({ error: message });
+      throw new Error(message);
+    } finally {
+      set({ isLoading: false });
     }
-  },
-
-  //resetting state
-  reset: () => {
-    set({
-      isLoading: false,
-      error: null,
-      success: false,
-      signUpSuccess: false,
-      forgotPasswordSuccess: false,
-      passwordResetSuccess: false,
-    });
   },
 }));

--- a/src/types/authTypes.ts
+++ b/src/types/authTypes.ts
@@ -9,18 +9,12 @@ export interface AuthState {
   isLoading: boolean;
   error: string | null;
   token: string | null;
-  success: boolean;
-
-  signUpSuccess: boolean;
-  forgotPasswordSuccess: boolean;
-  passwordResetSuccess: boolean;
 
   signUp: (data: SignUpFormData) => Promise<void>;
   signIn: (data: SignInFormData) => Promise<void>;
   forgotPassword: (data: ForgotPasswordFormData) => Promise<void>;
   resetPassword: (data: RecoveryPasswordAPIData) => Promise<void>;
 
-  reset: () => void;
   setToken: (t: string | null) => void;
   hydrateFromStorage: () => void;
   logout: () => void;


### PR DESCRIPTION
# SDD - Pull Request

### Description
Major change: 
- Started using try blocks for authForm's onSubmit and ditched the old useEffects. Removed unecessary states (such as signInSuccess, forgotSuccess etc...) since the try block already handles these cases. Also refactored the authStore to correctly use try&catch blocks.
Minor changes:
.  api: altered the dev-backend port
.  profilePage: breaking an ininite loop caused by a recursive useeffect
.  authGuard: started reacting to the TOKEN instead of the user's state.
 
- To solidify the authentication process.

### Change type

- [x] Bug fix
- [x] New feature
- [x] Improving code
- [ ] Documentation

